### PR TITLE
Fixed Help button to show English document when localisation is english

### DIFF
--- a/CodeLocatorPlugin/src/main/java/com/bytedance/tools/codelocator/action/OpenDocAction.kt
+++ b/CodeLocatorPlugin/src/main/java/com/bytedance/tools/codelocator/action/OpenDocAction.kt
@@ -13,6 +13,12 @@ class OpenDocAction :
     override fun isEnable(e: AnActionEvent) = true
 
     override fun actionPerformed(e: AnActionEvent) {
+        val config = CodeLocatorUserConfig.loadConfig()
+        val docUrl = if(config.isEnglish()) {
+            NetUtils.DOC_URL_EN
+        } else {
+            NetUtils.DOC_URL
+        }
         IdeaUtils.openBrowser(e.project, NetUtils.DOC_URL)
         Mob.mob(Mob.Action.CLICK, Mob.Button.DOC)
     }

--- a/CodeLocatorPlugin/src/main/java/com/bytedance/tools/codelocator/model/CodeLocatorUserConfig.java
+++ b/CodeLocatorPlugin/src/main/java/com/bytedance/tools/codelocator/model/CodeLocatorUserConfig.java
@@ -448,6 +448,10 @@ public class CodeLocatorUserConfig {
         this.autoFormatCode = autoFormatCode;
     }
 
+    public boolean isEnglish() {
+        return this.res == "en"
+    }
+
     @NotNull
     public static CodeLocatorUserConfig loadConfig() {
         if (sCodeLocatorConfig != null) {

--- a/CodeLocatorPlugin/src/main/java/com/bytedance/tools/codelocator/utils/NetUtils.java
+++ b/CodeLocatorPlugin/src/main/java/com/bytedance/tools/codelocator/utils/NetUtils.java
@@ -19,6 +19,8 @@ public class NetUtils {
 
     public static final String DOC_URL = "https://github.com/bytedance/CodeLocator/blob/main/how_to_use_codelocator_zh.md";
 
+    public static final String DOC_URL_EN = "https://github.com/bytedance/CodeLocator/blob/main/how_to_use_codelocator.md";
+
     public static final String SERVER_URL = "https://c76297c446.goho.co/log.php";
 
     public static final String FILE_SERVER_URL = "https://c76297c446.goho.co/upload.php";


### PR DESCRIPTION
Currently clicking on the help button always send the user to the help button.

this fix check for the localisation (en/zh) and send the user to the appropriate documentation.